### PR TITLE
[GR-1768] docs: note that this validator has moved to the Hub monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# ⚠️ This validator has moved
+
+This validator now lives in the [Guardrails Hub monorepo](https://github.com/guardrails-ai/guardrails-hub-monorepo/tree/main/relevancy_evaluator).
+**This repository is archived and no longer maintained** — please open issues and pull
+requests on the monorepo instead.
+
+```bash
+pip install guardrails-ai-relevancy-evaluator
+```
+
+```python
+from guardrails import Guard
+from guardrails_ai.relevancy_evaluator import RelevancyEvaluator
+
+guard = Guard().use(RelevancyEvaluator)
+```
+
+The registered validator name is unchanged, so existing guards keep working.
+
+---
+
 # Overview
 
 | Developed by | harrison@arize.com |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⚠️ This validator has moved
 
-This validator now lives in the [Guardrails Hub monorepo](https://github.com/guardrails-ai/guardrails-hub-monorepo/tree/main/relevancy_evaluator).
+This validator now lives in the [Guardrails Hub monorepo](https://github.com/guardrails-ai/guardrails-hub-monorepo/tree/main/relevancy_evaluator/py).
 **This repository is archived and no longer maintained** — please open issues and pull
 requests on the monorepo instead.
 


### PR DESCRIPTION
Consolidation follow-up for [GR-1768](https://linear.app/guardrailsai/issue/GR-1768/archive-validator-hub-repos).

This validator now lives in the [Guardrails Hub monorepo](https://github.com/guardrails-ai/guardrails-hub-monorepo/tree/main/relevancy_evaluator/py),
published to PyPI as `guardrails-ai-relevancy-evaluator`. This PR prepends a migration notice to the README
directing users there and stating that this repo is archived.

The existing README content is kept below the notice, so the archived repo still
documents the validator for anyone who lands here from an old link.

Archiving the repo itself is a separate manual step after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)